### PR TITLE
Fix help command.

### DIFF
--- a/scripts/leankit.coffee
+++ b/scripts/leankit.coffee
@@ -177,5 +177,5 @@ module.exports = (robot) ->
 
   robot.hear /^leankit help/i, (msg) ->
     commands = robot.helpCommands()
-    commands = (command for command in commands when command.match(/lk/))
+    commands = (command for command in commands when command.match(/leankit/))
     msg.send commands.join("\n")


### PR DESCRIPTION
Appears the commands used to all have 'lk' in them:
https://github.com/battlemidget/hubot-leankit/commit/3a7ffffdb10d876f4cd168cc3b16a27885701d3b

They now all have 'leankit' in them.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/battlemidget/hubot-leankit/4)
<!-- Reviewable:end -->
