### PR TITLE
Update to latest tagged version of leankit-node-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/battlemidget/hubot-leankit",
   "dependencies": {
-    "leankit-client": "^0.2.0",
+    "leankit-client": "^0.6.0",
     "lodash": "^2.4.1"
   }
 }

--- a/scripts/leankit.coffee
+++ b/scripts/leankit.coffee
@@ -41,7 +41,7 @@ module.exports = (robot) ->
   unless process.env.LEANKIT_ACCOUNT?
     return robot.logger.error "LEANKIT_ACCOUNT env var not set."
 
-  client = lk.newClient(process.env.LEANKIT_ACCOUNT,
+  client = lk.createClient(process.env.LEANKIT_ACCOUNT,
                         process.env.LEANKIT_EMAIL,
                         process.env.LEANKIT_PASSWORD)
 


### PR DESCRIPTION
Updating to the latest tag of https://github.com/LeanKit/leankit-node-client

However it does look like there is a 1.0.0 around the corner since there recently was a 1.0.0-beta added at https://www.npmjs.com/package/leankit-client

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/battlemidget/hubot-leankit/5)

<!-- Reviewable:end -->
